### PR TITLE
Add support for PHPUnit 9

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,8 +3,8 @@ name: Run tests
 on: [push]
 
 jobs:
-  phpunit:
-    name: Run tests
+  phpunit-8:
+    name: Run PHPUnit 8.x
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -18,8 +18,29 @@ jobs:
       - name: Run composer install
         run: composer install -n --prefer-dist
 
-      - name: Install PHPUnit 7.5
-        run: composer update -n phpunit/phpunit:^7.5 --with-dependencies
+      - name: Install PHPUnit 8.x
+        run: composer update -n phpunit/phpunit:^8.0 --with-dependencies
+
+      - name: Run tests
+        run: ./vendor/bin/phpunit
+
+  phpunit-9:
+    name: Run PHPUnit 9.x
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+
+      - name: Run composer install
+        run: composer install -n --prefer-dist
+
+      - name: Install PHPUnit 9.x
+        run: composer update -n phpunit/phpunit:^9.0 --with-dependencies
 
       - name: Run tests
         run: ./vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea/
 /vendor/
 /composer.lock
 /phpcs.xml

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,13 @@
         }
     ],
     "require": {
-        "phpunit/phpunit": "^7.1 || ^8.0"
+        "php": ">=7.4",
+        "phpunit/phpunit": "^8.0 || ^9.0"
     },
     "require-dev": {
         "escapestudios/symfony2-coding-standard": "^3.0",
-        "slevomat/coding-standard": "^5.0",
-        "squizlabs/php_codesniffer": "^3.1"
+        "slevomat/coding-standard": "^6.3",
+        "squizlabs/php_codesniffer": "^3.9"
     },
     "suggest": {
         "squizlabs/php_codesniffer": "^3.0"

--- a/src/Standards/ForkNetwork/Tests/AbstractSniffTest.php
+++ b/src/Standards/ForkNetwork/Tests/AbstractSniffTest.php
@@ -41,12 +41,25 @@ abstract class AbstractSniffTest extends AbstractSniffUnitTest
      * Sets the directories where the standards and tests can be found. The sniff codes array also needs to be set for
      * the errors to work properly.
      *
-     * @throws RuntimeException
+     * @param string|null $name
+     * @param array $data
+     * @param string $dataName
      * @throws \ReflectionException
+     */
+    public function __construct(?string $name = null, array $data = [], $dataName = '')
+    {
+        $this->setUpCodesnifferVariables();
+
+        parent::__construct($name, $data, $dataName);
+    }
+
+    /**
+     * Sets the custom ruleset if there is one.
+     *
+     * @throws RuntimeException
      */
     protected function setUp(): void
     {
-        $this->setUpCodesnifferVariables();
         $this->setUpCustomRuleset();
 
         parent::setUp();
@@ -101,10 +114,6 @@ abstract class AbstractSniffTest extends AbstractSniffUnitTest
         $GLOBALS['PHP_CODESNIFFER_TEST_DIRS'][$class] = $standardsDirectory . '/Tests/';
         $GLOBALS['PHP_CODESNIFFER_SNIFF_CODES'] = [];
         $GLOBALS['PHP_CODESNIFFER_FIXABLE_CODES'] = [];
-
-//        if (defined('PHP_CODESNIFFER_VERBOSITY') === false) {
-//            define('PHP_CODESNIFFER_VERBOSITY', 0);
-//        }
     }
 
     /**

--- a/src/Standards/ForkNetwork/Tests/PHPUnit/StrictUnitTestRuleset.xml
+++ b/src/Standards/ForkNetwork/Tests/PHPUnit/StrictUnitTestRuleset.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<ruleset name="StrictUnitTestSniff">
+    <description>Custom ruleset to test the StrictUnitTestSniff with a path.</description>
+
+    <!-- Rule to test (relative from this file, because it is including something in this file). -->
+    <rule ref="../../Sniffs/PHPUnit/StrictUnitTestSniff.php"/>
+</ruleset>

--- a/tests/Framework/StrictTestCaseTest.php
+++ b/tests/Framework/StrictTestCaseTest.php
@@ -4,7 +4,7 @@ namespace ForkNetwork\StrictPHPUnit\Tests\Framework;
 
 use ForkNetwork\StrictPHPUnit\StrictTestTrait;
 use ForkNetwork\StrictPHPUnit\Tests\Framework\Fixtures\GenericClass;
-use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\Exception as PHPUnitException;
 use PHPUnit\Framework\TestCase;
 
 class StrictTestCaseTest extends TestCase
@@ -50,7 +50,7 @@ class StrictTestCaseTest extends TestCase
         $testCaseMock = $this->getMockBuilder(TestCase::class)
             ->getMock();
 
-        $this->expectException(ExpectationFailedException::class);
+        $this->expectException(PHPUnitException::class);
 
         $this->genericClass->callsOneMethod($testCaseMock);
     }
@@ -77,7 +77,7 @@ class StrictTestCaseTest extends TestCase
     {
         $testCaseMock = $this->createMock(TestCase::class);
 
-        $this->expectException(ExpectationFailedException::class);
+        $this->expectException(PHPUnitException::class);
 
         $this->genericClass->callsOneMethod($testCaseMock);
     }


### PR DESCRIPTION
 * Updated unit tests to support both version 8 and 9 of PHPUnit.
 * Refactored GitHub Actions to run the tests in both PHPUnit 8 and 9.